### PR TITLE
Use media query to target non-retina displays

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,12 @@ exports.decorateConfig = (config) => {
   return Object.assign({}, config, {
     termCSS: `
       ${config.termCSS || ''}
-      x-screen {
-        -webkit-font-smoothing: subpixel-antialiased !important;
+      @media 
+      (-webkit-max-device-pixel-ratio: 1.3), 
+      (max-resolution: 120dpi) { 
+        x-screen {
+          -webkit-font-smoothing: subpixel-antialiased !important;
+        }
       }
     `
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperterm-subpixel-antialiased",
-  "version": "0.0.3",
+  "version": "0.1.0-0",
   "main": "index.js",
   "description": "Subpixel-antialiased font smoothing for hyperterm",
   "author": "Ali Ukani <ali.ukani@gmail.com>",


### PR DESCRIPTION
Uses a media query to only change the font smoothing on non-retina displays. Retina displays will use the default font smoothing (antialiased).
