### PR TITLE
Revert #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,8 @@ exports.decorateConfig = (config) => {
   return Object.assign({}, config, {
     termCSS: `
       ${config.termCSS || ''}
-      @media
-      (-webkit-max-device-pixel-ratio: 1.3),
-      (max-resolution: 120dpi) {
-        x-screen {
-          -webkit-font-smoothing: subpixel-antialiased !important;
-        }
+      x-screen {
+        -webkit-font-smoothing: subpixel-antialiased !important;
       }
     `
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-font-smoothing",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "index.js",
   "description": "Extension for subpixel-antialiased font smoothing in Hyper",
   "author": "Ali Ukani <ali.ukani@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hyper-font-smoothing",
+  "version": "1.0.0",
   "main": "index.js",
   "description": "Extension for subpixel-antialiased font smoothing in Hyper",
   "author": "Ali Ukani <ali.ukani@gmail.com>",


### PR DESCRIPTION
I might have missed something but #1 seemed unnecessary, and potentially confusing, at least with Hyper 1.4.8.

Consider this:

> User has a retina screen, and wants to disable the default antialiasing so goes for a plugin because it's easier than adding:
> ```
> termCSS: `
>   x-screen {
>     -webkit-font-smoothing: subpixel-antialiased !important;
>   }
> `,
> ```
> to the config.
> 
> The plugin assumes that it knows better , and does absolutely nothing.

I've found the above scenario confusing so reverted #1, and bumped major version number as this might surprise those on retina screens.